### PR TITLE
Added an optional flag to change the container's user in "shell"

### DIFF
--- a/app/cmd/docker/shell.go
+++ b/app/cmd/docker/shell.go
@@ -12,10 +12,18 @@ var CmdComposeShell = cli.Command{
 	Usage:       "run shell from main service",
 	Description: `Execute shell cmd in main service`,
 	Action:      RunComposeShell,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "user",
+			Aliases:  []string{"u"},
+			Usage:    "Username or UID (format: <name|uid>)",
+			Required: false,
+		},
+	},
 }
 
 func RunComposeShell(cmd *cli.Context) error {
 	ctx := context.InitCommand(cmd)
-	compose.ExecComposerShell(ctx)
+	compose.ExecComposerShell(ctx, *cmd)
 	return nil
 }

--- a/app/modules/compose/compose.go
+++ b/app/modules/compose/compose.go
@@ -36,7 +36,7 @@ func CheckDockerComposeVersion() {
 	composeSemVer, _ := semver.NewVersion(composeVersion)
 
 	if !verConstraint.Check(composeSemVer) {
-		logger.Critical("Wrong docker-compose version, please update to " + DockerComposeVersion + " or higher.", nil)
+		logger.Critical("Wrong docker-compose version, please update to "+DockerComposeVersion+" or higher.", nil)
 	}
 }
 
@@ -164,10 +164,15 @@ func ExecComposerRm(ctx *context.LedoContext) {
 	ctx.ExecCmd("docker-compose", args[0:])
 }
 
-func ExecComposerShell(ctx *context.LedoContext) {
+func ExecComposerShell(ctx *context.LedoContext, command cli.Context) {
 	PrintCurrentMode(ctx)
 	args := ctx.ComposeArgs
-	args = append(args, "exec", strings.ToLower(ctx.Config.Docker.MainService), ctx.Config.Docker.Shell)
+	args = append(args, "exec")
+	user := command.String("user")
+	if user != "" {
+		args = append(args, "--user", user)
+	}
+	args = append(args, strings.ToLower(ctx.Config.Docker.MainService), ctx.Config.Docker.Shell)
 	ctx.ExecCmd("docker-compose", args[0:])
 }
 


### PR DESCRIPTION
The following changes add an additional, optional flag `--user, -u`, which allows changing the container's user on `shell` command.

Example:  
```shell
$ ledo docker shell
 MODE  dev
 EXECUTE  docker-compose --env-file .env --project-name vertisan -f docker/docker-compose.yml -f docker/docker-compose.dev.yml exec api /bin/bash
root@3918088025b2:/var/www# id
uid=0(root) gid=0(root) groups=0(root)
```

```shell
$ ledo docker shell --user 1000
 MODE  dev
 EXECUTE  docker-compose --env-file .env --project-name vertisan -f docker/docker-compose.yml -f docker/docker-compose.dev.yml exec --user 1000 api /bin/bash
node@3918088025b2:/var/www$ id
uid=1000(node) gid=1000(node) groups=1000(node)
```