### PR TITLE
Resolve the config paths from the repository root.

### DIFF
--- a/app/modules/compose/compose.go
+++ b/app/modules/compose/compose.go
@@ -50,7 +50,7 @@ func MergeComposerFiles(filenames ...string) (string, error) {
 	for _, filename := range filenames {
 
 		var override map[string]interface{}
-		bs, err := ioutil.ReadFile(filename)
+		bs, err := ioutil.ReadFile(context.ResolveRootPath(filename))
 		if err != nil {
 			logger.Error("Merge compose error", err)
 			continue

--- a/app/modules/git/git.go
+++ b/app/modules/git/git.go
@@ -1,0 +1,15 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func GetRepositoryRootDir() (string, error) {
+	path, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(path)), nil
+}


### PR DESCRIPTION
The following PR proposes an extra solution that allows to use of `ledo` commands in subdirectories of the project, not only in the root.